### PR TITLE
feature/33-add-chat-data-classes

### DIFF
--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Channel.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Channel.java
@@ -60,12 +60,13 @@ public class Channel extends TableModelAutoId {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Channel channel = (Channel) o;
-        return Objects.equals(getName(), channel.getName());
+        return Objects.equals(getName(), channel.getName()) &&
+                Objects.equals(getId(), channel.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName());
+        return Objects.hash(getId(), getName());
     }
 
     @Override

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Channel.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Channel.java
@@ -1,0 +1,78 @@
+package net.cryptic_game.backend.data.Chat;
+
+import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
+import net.cryptic_game.backend.base.utils.JsonBuilder;
+import org.hibernate.Session;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "channel")
+public class Channel extends TableModelAutoId {
+
+    @Column(name = "name", updatable = true, nullable = false)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public static Channel createChannel(final String name) {
+        final Channel channel = new Channel();
+        channel.setName(name);
+
+        final Session session = sqlConnection.openSession();
+        session.beginTransaction();
+        session.save(channel);
+        session.getTransaction().commit();
+        session.close();
+        return channel;
+    }
+
+    public static void removeChannel(final UUID id) {
+        final Channel channel = getById(id);
+        if(channel != null) {
+            final Session session = sqlConnection.openSession();
+            session.beginTransaction();
+            session.delete(channel);
+            session.getTransaction().commit();
+            session.close();
+        }
+    }
+
+    public static Channel getById(final UUID id) {
+        return getById(Channel.class, id);
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Channel channel = (Channel) o;
+        return Objects.equals(getName(), channel.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
+
+    @Override
+    public JsonObject serialize() {
+        return JsonBuilder.anJSON()
+                .add("id", this.getId())
+                .add("name", this.getName())
+                .build();
+    }
+}

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/ChannelAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/ChannelAccess.java
@@ -1,0 +1,106 @@
+package net.cryptic_game.backend.data.Chat;
+
+import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
+import net.cryptic_game.backend.base.utils.JsonBuilder;
+import net.cryptic_game.backend.data.user.User;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "channel_access")
+public class ChannelAccess extends TableModelAutoId {
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", updatable = false, nullable = false)
+    @Type(type = "uuid-char")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "channel_id", nullable = false, updatable = false)
+    @Type(type = "uuid-char")
+    private Channel channel;
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public void setChannel(Channel channel) {
+        this.channel = channel;
+    }
+
+    public static ChannelAccess join(User user, Channel channel) {
+        Session sqlSession = sqlConnection.openSession();
+
+        ChannelAccess channelAccess = new ChannelAccess();
+        channelAccess.setUser(user);
+        channelAccess.setChannel(channel);
+
+        sqlSession.beginTransaction();
+        sqlSession.save(channelAccess);
+        sqlSession.getTransaction().commit();
+        sqlSession.close();
+        return channelAccess;
+    }
+
+    public static boolean leave(User user, Channel channel) {
+        try (Session sqlSession = sqlConnection.openSession()) {
+            sqlSession
+                    .createQuery("delete from ChannelAccess ca where ca.channel = :channel and ca.user = :user")
+                    .setParameter("channel", channel)
+                    .setParameter("user", user);
+            return true;
+        } catch (HibernateException e) {
+            return false;
+        }
+    }
+
+    public static List<User> getMembers(final Channel channel) {
+
+        try (Session sqlSession = sqlConnection.openSession()) {
+            return sqlSession
+                    .createQuery("select object (u) from User u where u.id in (select ca.user from ChannelAccess ca where ca.channel = :channel)", User.class)
+                    .setParameter("channel", channel)
+                    .getResultList();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChannelAccess that = (ChannelAccess) o;
+        return Objects.equals(getUser(), that.getUser()) &&
+                Objects.equals(getChannel(), that.getChannel());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUser(), getChannel());
+    }
+
+    public JsonObject serialize() {
+        return JsonBuilder.anJSON()
+                .add("id", this.getId())
+                .add("user_id", this.getUser().getId())
+                .add("channel_id", this.getChannel().getId())
+                .build();
+    }
+}
+

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/ChannelAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/ChannelAccess.java
@@ -15,6 +15,9 @@ import javax.persistence.Table;
 import java.util.List;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Entity
 @Table(name = "channel_access")
 public class ChannelAccess extends TableModelAutoId {
@@ -67,6 +70,8 @@ public class ChannelAccess extends TableModelAutoId {
                     .setParameter("user", user);
             return true;
         } catch (HibernateException e) {
+            final Logger log = LoggerFactory.getLogger(ChannelAccess.class);
+            log.error("The user wasn't found in the channel. Therefore he can't leave the channel" + e);
             return false;
         }
     }
@@ -87,12 +92,13 @@ public class ChannelAccess extends TableModelAutoId {
         if (o == null || getClass() != o.getClass()) return false;
         ChannelAccess that = (ChannelAccess) o;
         return Objects.equals(getUser(), that.getUser()) &&
-                Objects.equals(getChannel(), that.getChannel());
+                Objects.equals(getChannel(), that.getChannel()) &&
+                Objects.equals(getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUser(), getChannel());
+        return Objects.hash(getId(), getUser(), getChannel());
     }
 
     public JsonObject serialize() {

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/ChatAction.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/ChatAction.java
@@ -1,0 +1,21 @@
+package net.cryptic_game.backend.data.Chat;
+
+public enum ChatAction {
+    MEMBER_JOIN("member-join"),
+    MEMBER_LEAVE("member-leave"),
+
+    SEND_MESSAGE("send-message"),
+    WHISPER_MESSAGE("whisper-message"),
+
+    CHANNEL_DELETE("channel-delete");
+
+    final String value;
+
+    ChatAction(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Message.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Message.java
@@ -124,12 +124,13 @@ public class Message extends TableModelAutoId {
                 Objects.equals(getChannel(), message.getChannel()) &&
                 getType() == message.getType() &&
                 Objects.equals(getText(), message.getText()) &&
-                Objects.equals(getTarget(), message.getTarget());
+                Objects.equals(getTarget(), message.getTarget()) &&
+                Objects.equals(getId(), message.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUser(), getChannel(), getType(), getText(), getTarget());
+        return Objects.hash(getId(), getUser(), getChannel(), getType(), getText(), getTarget());
     }
 
     @Override

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Message.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Message.java
@@ -1,0 +1,147 @@
+package net.cryptic_game.backend.data.Chat;
+
+import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
+import net.cryptic_game.backend.base.utils.JsonBuilder;
+import net.cryptic_game.backend.data.user.User;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "message")
+public class Message extends TableModelAutoId {
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", updatable = false, nullable = false)
+    @Type(type = "uuid-char")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "channel_id", nullable = false, updatable = false)
+    @Type(type = "uuid-char")
+    private Channel channel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(updatable = false)
+    private ChatAction type;
+
+    @Column(name = "text", updatable = false, nullable = true)
+    private String text;
+
+    /**
+     * user id of the target, if it's not a whisper its null and targets consequently
+     * everyone in the channel
+     */
+    @OneToOne
+    @Column(name = "target", updatable = false, nullable = true)
+    private User target;
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public void setChannel(Channel channel) {
+        this.channel = channel;
+    }
+
+    public ChatAction getType() {
+        return type;
+    }
+
+    public void setType(ChatAction type) {
+        this.type = type;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public User getTarget() {
+        return target;
+    }
+
+    public void setTarget(User target) {
+        this.target = target;
+    }
+
+    public void send(Channel channel, User user, String text) {
+        send(channel, user, ChatAction.SEND_MESSAGE, text);
+    }
+
+    public void send(Channel channel, User user, ChatAction type, String text) {
+        send(channel, user, null, type, text);
+    }
+
+    public Message send(Channel channel, User user, User target, ChatAction type, String text) {
+        Session sqlSession = sqlConnection.openSession();
+
+        Message message = new Message();
+        message.setUser(user);
+        message.setChannel(channel);
+        message.setTarget(target);
+        message.setType(type);
+        message.setText(text);
+
+        sqlSession.beginTransaction();
+        sqlSession.save(message);
+        sqlSession.getTransaction().commit();
+        sqlSession.close();
+        return message;
+    }
+
+    public List<Message> getMessages(User user, Channel channel) {
+        try (Session sqlSession = sqlConnection.openSession()) {
+            return sqlSession
+                    .createQuery("select object (m) from Message m where  m.channel = :channel and (m.target is null or (m.type = :whisper and m.target = :user))", Message.class)
+                    .setParameter("user", user)
+                    .setParameter("channel", channel)
+                    .setParameter("whisper", ChatAction.WHISPER_MESSAGE)
+                    .getResultList();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Message message = (Message) o;
+        return Objects.equals(getUser(), message.getUser()) &&
+                Objects.equals(getChannel(), message.getChannel()) &&
+                getType() == message.getType() &&
+                Objects.equals(getText(), message.getText()) &&
+                Objects.equals(getTarget(), message.getTarget());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUser(), getChannel(), getType(), getText(), getTarget());
+    }
+
+    @Override
+    public JsonObject serialize() {
+        return JsonBuilder.anJSON()
+                .add("id", this.getId())
+                .add("channel", this.getChannel().getId())
+                .add("user", this.getUser().getId())
+                .add("type", this.getType().toString())
+                .add("target", this.getTarget().toString())
+                .add("text", this.getText())
+                .build();
+    }
+}

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Message.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Chat/Message.java
@@ -80,12 +80,10 @@ public class Message extends TableModelAutoId {
         this.target = target;
     }
 
-    public void send(Channel channel, User user, String text) {
-        send(channel, user, ChatAction.SEND_MESSAGE, text);
-    }
+    public Message send(Channel channel, User user, String text) { return send(channel, user, ChatAction.SEND_MESSAGE, text); }
 
-    public void send(Channel channel, User user, ChatAction type, String text) {
-        send(channel, user, null, type, text);
+    public Message send(Channel channel, User user, ChatAction type, String text) {
+        return send(channel, user, null, type, text);
     }
 
     public Message send(Channel channel, User user, User target, ChatAction type, String text) {
@@ -108,7 +106,8 @@ public class Message extends TableModelAutoId {
     public List<Message> getMessages(User user, Channel channel) {
         try (Session sqlSession = sqlConnection.openSession()) {
             return sqlSession
-                    .createQuery("select object (m) from Message m where  m.channel = :channel and (m.target is null or (m.type = :whisper and m.target = :user))", Message.class)
+                    .createQuery("select object (m) from Message m where  m.channel = :channel " +
+                            "and (m.target is null or (m.type = :whisper and m.target = :user) or (m.type = :whisper and m.user = :user))", Message.class)
                     .setParameter("user", user)
                     .setParameter("channel", channel)
                     .setParameter("whisper", ChatAction.WHISPER_MESSAGE)

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
@@ -3,7 +3,6 @@ package net.cryptic_game.backend.data.chat;
 import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
 import net.cryptic_game.backend.base.utils.JsonBuilder;
-import org.hibernate.Session;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -18,14 +17,6 @@ public class Channel extends TableModelAutoId {
     @Column(name = "name", updatable = true, nullable = false)
     private String name;
 
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public static Channel createChannel(final String name) {
         final Channel channel = new Channel();
         channel.setName(name);
@@ -36,13 +27,21 @@ public class Channel extends TableModelAutoId {
 
     public static void removeChannel(final UUID id) {
         final Channel channel = getById(id);
-        if(channel != null) {
+        if (channel != null) {
             channel.delete();
         }
     }
 
     public static Channel getById(final UUID id) {
         return getById(Channel.class, id);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Override

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
@@ -1,4 +1,4 @@
-package net.cryptic_game.backend.data.Chat;
+package net.cryptic_game.backend.data.chat;
 
 import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
@@ -12,7 +12,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Entity
-@Table(name = "channel")
+@Table(name = "chat_channel")
 public class Channel extends TableModelAutoId {
 
     @Column(name = "name", updatable = true, nullable = false)
@@ -41,19 +41,13 @@ public class Channel extends TableModelAutoId {
     public static void removeChannel(final UUID id) {
         final Channel channel = getById(id);
         if(channel != null) {
-            final Session session = sqlConnection.openSession();
-            session.beginTransaction();
-            session.delete(channel);
-            session.getTransaction().commit();
-            session.close();
+            channel.delete();
         }
     }
 
     public static Channel getById(final UUID id) {
         return getById(Channel.class, id);
     }
-
-
 
     @Override
     public boolean equals(Object o) {

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
@@ -48,7 +48,7 @@ public class Channel extends TableModelAutoId {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Channel channel = (Channel) o;
+        final Channel channel = (Channel) o;
         return Objects.equals(getName(), channel.getName()) &&
                 Objects.equals(getId(), channel.getId());
     }

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Channel.java
@@ -30,11 +30,7 @@ public class Channel extends TableModelAutoId {
         final Channel channel = new Channel();
         channel.setName(name);
 
-        final Session session = sqlConnection.openSession();
-        session.beginTransaction();
-        session.save(channel);
-        session.getTransaction().commit();
-        session.close();
+        channel.saveOrUpdate();
         return channel;
     }
 

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
@@ -57,10 +57,7 @@ public class ChannelAccess extends TableModelAutoId {
         channelAccess.setUser(user);
         channelAccess.setChannel(channel);
 
-        sqlSession.beginTransaction();
-        sqlSession.save(channelAccess);
-        sqlSession.getTransaction().commit();
-        sqlSession.close();
+        channelAccess.saveOrUpdate();
         return channelAccess;
     }
 

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
@@ -23,6 +23,8 @@ import java.util.Set;
 @Table(name = "chat_channel_access")
 public class ChannelAccess extends TableModelAutoId {
 
+    private static final Logger log = LoggerFactory.getLogger(ChannelAccess.class);
+
     @ManyToOne
     @JoinColumn(name = "user_id", updatable = false, nullable = false)
     @Type(type = "uuid-char")
@@ -50,7 +52,6 @@ public class ChannelAccess extends TableModelAutoId {
                     .setParameter("user", user);
             return true;
         } catch (HibernateException e) {
-            final Logger log = LoggerFactory.getLogger(ChannelAccess.class);
             log.error("The user wasn't found in the channel. Therefore he can't leave the channel", e);
             return false;
         }
@@ -86,7 +87,7 @@ public class ChannelAccess extends TableModelAutoId {
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (!(o instanceof ChannelAccess)) return false;
-        ChannelAccess that = (ChannelAccess) o;
+        final ChannelAccess that = (ChannelAccess) o;
         return this.getId().equals(that.getId()) &&
                 this.getUser().equals(that.getUser()) &&
                 this.getChannel().equals(that.getChannel());

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
@@ -1,6 +1,7 @@
-package net.cryptic_game.backend.data.Chat;
+package net.cryptic_game.backend.data.chat;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.api.client.ApiClient;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
 import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
@@ -14,12 +15,13 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Entity
-@Table(name = "channel_access")
+@Table(name = "chat_channel_access")
 public class ChannelAccess extends TableModelAutoId {
 
     @ManyToOne
@@ -44,11 +46,11 @@ public class ChannelAccess extends TableModelAutoId {
         return channel;
     }
 
-    public void setChannel(Channel channel) {
+    public void setChannel(final Channel channel) {
         this.channel = channel;
     }
 
-    public static ChannelAccess join(User user, Channel channel) {
+    public static ChannelAccess join(final User user, final Channel channel, final Set<ApiClient> notifyUsers) {
         Session sqlSession = sqlConnection.openSession();
 
         ChannelAccess channelAccess = new ChannelAccess();
@@ -62,7 +64,7 @@ public class ChannelAccess extends TableModelAutoId {
         return channelAccess;
     }
 
-    public static boolean leave(User user, Channel channel) {
+    public static boolean leave(final User user, final Channel channel, Set<ApiClient> notifyUsers) {
         try (Session sqlSession = sqlConnection.openSession()) {
             sqlSession
                     .createQuery("delete from ChannelAccess ca where ca.channel = :channel and ca.user = :user")

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChannelAccess.java
@@ -8,6 +8,8 @@ import net.cryptic_game.backend.data.user.User;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -16,9 +18,6 @@ import javax.persistence.Table;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Entity
 @Table(name = "chat_channel_access")
@@ -34,25 +33,7 @@ public class ChannelAccess extends TableModelAutoId {
     @Type(type = "uuid-char")
     private Channel channel;
 
-    public User getUser() {
-        return user;
-    }
-
-    public void setUser(User user) {
-        this.user = user;
-    }
-
-    public Channel getChannel() {
-        return channel;
-    }
-
-    public void setChannel(final Channel channel) {
-        this.channel = channel;
-    }
-
     public static ChannelAccess join(final User user, final Channel channel, final Set<ApiClient> notifyUsers) {
-        Session sqlSession = sqlConnection.openSession();
-
         ChannelAccess channelAccess = new ChannelAccess();
         channelAccess.setUser(user);
         channelAccess.setChannel(channel);
@@ -70,7 +51,7 @@ public class ChannelAccess extends TableModelAutoId {
             return true;
         } catch (HibernateException e) {
             final Logger log = LoggerFactory.getLogger(ChannelAccess.class);
-            log.error("The user wasn't found in the channel. Therefore he can't leave the channel" + e);
+            log.error("The user wasn't found in the channel. Therefore he can't leave the channel", e);
             return false;
         }
     }
@@ -85,19 +66,35 @@ public class ChannelAccess extends TableModelAutoId {
         }
     }
 
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public void setChannel(final Channel channel) {
+        this.channel = channel;
+    }
+
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof ChannelAccess)) return false;
         ChannelAccess that = (ChannelAccess) o;
-        return Objects.equals(getUser(), that.getUser()) &&
-                Objects.equals(getChannel(), that.getChannel()) &&
-                Objects.equals(getId(), that.getId());
+        return this.getId().equals(that.getId()) &&
+                this.getUser().equals(that.getUser()) &&
+                this.getChannel().equals(that.getChannel());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getUser(), getChannel());
+        return Objects.hash(this.getId(), this.getUser(), this.getChannel());
     }
 
     public JsonObject serialize() {

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatAction.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatAction.java
@@ -1,4 +1,4 @@
-package net.cryptic_game.backend.data.Chat;
+package net.cryptic_game.backend.data.chat;
 
 public enum ChatAction {
     MEMBER_JOIN("member-join"),

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
@@ -88,9 +88,7 @@ public class Message extends TableModelAutoId {
     }
 
     public Message send(final Channel channel, final User user, final User target, final ChatAction type, final String text) {
-        Session sqlSession = sqlConnection.openSession();
-
-        Message message = new Message();
+        final Message message = new Message();
         message.setUser(user);
         message.setChannel(channel);
         message.setTarget(target);
@@ -114,21 +112,21 @@ public class Message extends TableModelAutoId {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Message message = (Message) o;
-        return Objects.equals(getUser(), message.getUser()) &&
-                Objects.equals(getChannel(), message.getChannel()) &&
-                getType() == message.getType() &&
-                Objects.equals(getText(), message.getText()) &&
-                Objects.equals(getTarget(), message.getTarget()) &&
-                Objects.equals(getId(), message.getId());
+        if (!(o instanceof Message)) return false;
+        final Message message = (Message) o;
+        return this.getId().equals(message.getId()) &&
+                this.getUser().equals(message.getUser()) &&
+                this.getChannel().equals(message.getChannel()) &&
+                this.getType() == message.getType() &&
+                this.getText().equals(message.getText()) &&
+                Objects.equals(this.getTarget(), message.getTarget());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getUser(), getChannel(), getType(), getText(), getTarget());
+        return Objects.hash(this.getId(), this.getUser(), this.getChannel(), this.getType(), this.getText(), this.getTarget());
     }
 
     @Override

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
@@ -97,10 +97,7 @@ public class Message extends TableModelAutoId {
         message.setType(type);
         message.setText(text);
 
-        sqlSession.beginTransaction();
-        sqlSession.save(message);
-        sqlSession.getTransaction().commit();
-        sqlSession.close();
+        message.saveOrUpdate();
         return message;
     }
 

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
@@ -1,4 +1,4 @@
-package net.cryptic_game.backend.data.Chat;
+package net.cryptic_game.backend.data.chat;
 
 import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 @Entity
-@Table(name = "message")
+@Table(name = "chat_message")
 public class Message extends TableModelAutoId {
 
     @ManyToOne
@@ -33,8 +33,7 @@ public class Message extends TableModelAutoId {
     private String text;
 
     /**
-     * user id of the target, if it's not a whisper its null and targets consequently
-     * everyone in the channel
+     * User ID of the target, if it is not a whisper it is null and consequently targets everyone in the channel
      */
     @OneToOne
     @Column(name = "target", updatable = false, nullable = true)
@@ -44,7 +43,7 @@ public class Message extends TableModelAutoId {
         return user;
     }
 
-    public void setUser(User user) {
+    public void setUser(final User user) {
         this.user = user;
     }
 
@@ -52,7 +51,7 @@ public class Message extends TableModelAutoId {
         return channel;
     }
 
-    public void setChannel(Channel channel) {
+    public void setChannel(final Channel channel) {
         this.channel = channel;
     }
 
@@ -60,7 +59,7 @@ public class Message extends TableModelAutoId {
         return type;
     }
 
-    public void setType(ChatAction type) {
+    public void setType(final ChatAction type) {
         this.type = type;
     }
 
@@ -68,7 +67,7 @@ public class Message extends TableModelAutoId {
         return text;
     }
 
-    public void setText(String text) {
+    public void setText(final String text) {
         this.text = text;
     }
 
@@ -76,17 +75,19 @@ public class Message extends TableModelAutoId {
         return target;
     }
 
-    public void setTarget(User target) {
+    public void setTarget(final User target) {
         this.target = target;
     }
 
-    public Message send(Channel channel, User user, String text) { return send(channel, user, ChatAction.SEND_MESSAGE, text); }
+    public Message send(final Channel channel, final User user, final String text) {
+        return send(channel, user, ChatAction.SEND_MESSAGE, text);
+    }
 
-    public Message send(Channel channel, User user, ChatAction type, String text) {
+    public Message send(final Channel channel, final User user, final ChatAction type, final String text) {
         return send(channel, user, null, type, text);
     }
 
-    public Message send(Channel channel, User user, User target, ChatAction type, String text) {
+    public Message send(final Channel channel, final User user, final User target, final ChatAction type, final String text) {
         Session sqlSession = sqlConnection.openSession();
 
         Message message = new Message();
@@ -103,7 +104,7 @@ public class Message extends TableModelAutoId {
         return message;
     }
 
-    public List<Message> getMessages(User user, Channel channel) {
+    public List<Message> getMessages(final User user, final Channel channel) {
         try (Session sqlSession = sqlConnection.openSession()) {
             return sqlSession
                     .createQuery("select object (m) from Message m where  m.channel = :channel " +

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/Message.java
@@ -33,7 +33,7 @@ public class Message extends TableModelAutoId {
     private String text;
 
     /**
-     * User ID of the target, if it is not a whisper it is null and consequently targets everyone in the channel
+     * User ID of the target, if it is not a whisper it is null and consequently targets everyone in the channel.
      */
     @OneToOne
     @Column(name = "target", updatable = false, nullable = true)

--- a/server/src/main/java/net/cryptic_game/backend/server/App.java
+++ b/server/src/main/java/net/cryptic_game/backend/server/App.java
@@ -1,6 +1,7 @@
 package net.cryptic_game.backend.server;
 
 import io.netty.channel.unix.DomainSocketAddress;
+import io.sentry.Sentry;
 import net.cryptic_game.backend.base.AppBootstrap;
 import net.cryptic_game.backend.base.config.BaseConfig;
 import net.cryptic_game.backend.base.netty.server.NettyServerHandler;
@@ -81,5 +82,6 @@ public class App extends AppBootstrap {
     @Override
     protected void start() {
         this.serverHandler.start();
+        Sentry.capture(new Exception("test123"));
     }
 }


### PR DESCRIPTION
**Description**
implemented the data classes for the chat system
added Java Data Classes: Channel, Channel Access, Message
added enum ChatAction to classify the type of Message
(e.g. whisper-msg, send-message(normal msg), member-join...)

Closes #33 

**Testing Instructions**
1. Testing the channels
- call create channel to create a channel & see if an entry in the table is added
- call delete channel to delete a channel & see if the entry in the table is deleted
2. Testing the ChannelAccess Class
- test if users can be added to and deleted from a channel by calling ChannelAccess.join and
ChannelAccess.remove
- test if ChannelAccess.getMembers returns all memebs of a channel
3. Test the Message Class
- test the function Message.send() with different types of messages, like a normal message, a whisper, a member joining
- test if the functionMessage.getMessages() returns 
1. all messages sent to all users 
2. the whispered messages form or to the user

**Additional Notes**
/