### PR TITLE
Added name length check

### DIFF
--- a/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketUserEndpoints.java
+++ b/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketUserEndpoints.java
@@ -25,6 +25,10 @@ public class WebSocketUserEndpoints extends ApiEndpointCollection {
             return new ApiResponse(ApiResponseType.FORBIDDEN, "ALREADY_LOGGED_IN");
         }
 
+        if (name.length() > 256) {
+            return new ApiResponse(ApiResponseType.BAD_REQUEST, "INVALID_NAME");
+        }
+
         final User user = User.getByName(name);
 
         if (user == null) {
@@ -52,6 +56,10 @@ public class WebSocketUserEndpoints extends ApiEndpointCollection {
                                 @ApiParameter("device_name") final String deviceName) {
         if (client.get(Session.class) != null || client.get(User.class) != null) {
             return new ApiResponse(ApiResponseType.FORBIDDEN, "ALREADY_LOGGED_IN");
+        }
+
+        if (name.length() > 256) {
+            return new ApiResponse(ApiResponseType.BAD_REQUEST, "INVALID_NAME");
         }
 
         if (!ValidationUtils.checkPassword(password)) {


### PR DESCRIPTION
**Description**
Added an error message returned to the user if the username during the login / register process is longer than 265 characters.

**Issue**
Closes #44 

**Testing Instructions**
Try logging in / registering with a username longer than 265 characters.

**Additional Notes**
Later replace by JavaX Validators. See #43 
