### PR TITLE
Use new JsonBuilder

### DIFF
--- a/java-base/src/main/java/net/cryptic_game/backend/base/api/notification/NotificationEndpointCollection.java
+++ b/java-base/src/main/java/net/cryptic_game/backend/base/api/notification/NotificationEndpointCollection.java
@@ -2,7 +2,7 @@ package net.cryptic_game.backend.base.api.notification;
 
 import net.cryptic_game.backend.base.api.client.ApiClient;
 import net.cryptic_game.backend.base.api.endpoint.*;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 
 public class NotificationEndpointCollection extends ApiEndpointCollection {
 
@@ -16,7 +16,7 @@ public class NotificationEndpointCollection extends ApiEndpointCollection {
             @ApiParameter("topic") final String topic) {
 
         client.subscribe(topic);
-        return new ApiResponse(ApiResponseType.OK, JsonBuilder.simple("success", true));
+        return new ApiResponse(ApiResponseType.OK, JsonBuilder.create("success", true));
     }
 
     @ApiEndpoint("unsubscribe")
@@ -25,6 +25,6 @@ public class NotificationEndpointCollection extends ApiEndpointCollection {
             @ApiParameter("topic") final String topic) {
 
         client.unsubscribe(topic);
-        return new ApiResponse(ApiResponseType.OK, JsonBuilder.simple("success", true));
+        return new ApiResponse(ApiResponseType.OK, JsonBuilder.create("success", true));
     }
 }

--- a/java-base/src/main/java/net/cryptic_game/backend/base/daemon/Daemon.java
+++ b/java-base/src/main/java/net/cryptic_game/backend/base/daemon/Daemon.java
@@ -3,7 +3,7 @@ package net.cryptic_game.backend.base.daemon;
 import com.google.gson.JsonObject;
 import io.netty.channel.Channel;
 import net.cryptic_game.backend.base.interfaces.JsonSerializable;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -22,9 +22,8 @@ public class Daemon implements JsonSerializable {
 
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("name", this.getName())
-                .add("connected_since", this.getConnectedSince().toInstant(ZoneOffset.UTC).toEpochMilli())
+        return JsonBuilder.create("name", this.getName())
+                .add("connected_since", this.getConnectedSince().toInstant(ZoneOffset.UTC))
                 .build();
     }
 

--- a/java-base/src/main/java/net/cryptic_game/backend/base/daemon/DaemonRegisterPacket.java
+++ b/java-base/src/main/java/net/cryptic_game/backend/base/daemon/DaemonRegisterPacket.java
@@ -5,8 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.netty.channel.Channel;
 import net.cryptic_game.backend.base.interfaces.JsonSerializable;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
-import net.cryptic_game.backend.base.utils.JsonUtils;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -43,9 +42,8 @@ public class DaemonRegisterPacket implements JsonSerializable {
 
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("name", this.getName())
-                .add("functions", JsonUtils.toArray(this.functions))
+        return JsonBuilder.create("name", this.getName())
+                .add("functions", this.functions)
                 .build();
     }
 

--- a/java-base/src/main/java/net/cryptic_game/backend/base/daemon/Function.java
+++ b/java-base/src/main/java/net/cryptic_game/backend/base/daemon/Function.java
@@ -4,8 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.interfaces.JsonSerializable;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
-import net.cryptic_game.backend.base.utils.JsonUtils;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -47,9 +46,8 @@ public class Function implements JsonSerializable {
 
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("name", this.getName())
-                .add("arguments", JsonUtils.toArray(this.arguments))
+        return JsonBuilder.create("name", this.getName())
+                .add("arguments", this.arguments)
                 .build();
     }
 

--- a/java-base/src/main/java/net/cryptic_game/backend/base/daemon/FunctionArgument.java
+++ b/java-base/src/main/java/net/cryptic_game/backend/base/daemon/FunctionArgument.java
@@ -2,7 +2,7 @@ package net.cryptic_game.backend.base.daemon;
 
 import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.interfaces.JsonSerializable;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 
 public class FunctionArgument implements JsonSerializable {
 
@@ -25,8 +25,7 @@ public class FunctionArgument implements JsonSerializable {
 
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("name", this.getName())
+        return JsonBuilder.create("name", this.getName())
                 .add("required", this.isRequired())
                 .build();
     }

--- a/java-base/src/main/java/net/cryptic_game/backend/base/json/JsonBuilder.java
+++ b/java-base/src/main/java/net/cryptic_game/backend/base/json/JsonBuilder.java
@@ -60,12 +60,12 @@ public class JsonBuilder implements JsonSerializable {
     /**
      * Creates a {@link JsonBuilder} without any data.
      *
-     * @param json the existing {@link JsonObject}
+     * @param object the existing {@link JsonObject} ore any {@link JsonSerializable}, e.g.
      * @return the JsonBuilder
      * @see JsonBuilder#create(String, Object)
      */
-    public static JsonBuilder create(final JsonObject json) {
-        return new JsonBuilder(json);
+    public static JsonBuilder create(final Object object) {
+        return new JsonBuilder(JsonUtils.toJson(object).getAsJsonObject());
     }
 
     /**

--- a/java-base/src/main/java/net/cryptic_game/backend/base/utils/ApiUtils.java
+++ b/java-base/src/main/java/net/cryptic_game/backend/base/utils/ApiUtils.java
@@ -3,6 +3,7 @@ package net.cryptic_game.backend.base.utils;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.netty.channel.Channel;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 
 import java.util.UUID;
 
@@ -11,11 +12,10 @@ public class ApiUtils {
     public static UUID request(final Channel channel, final String endpoint, final JsonObject data) {
         final UUID tag = UUID.randomUUID();
 
-        final JsonBuilder builder = JsonBuilder.anJSON()
-                .add("tag", tag.toString())
+        final JsonBuilder builder = JsonBuilder.create("tag", tag.toString())
                 .add("endpoint", endpoint)
-                .add("response", false);
-        if (data != null) builder.add("data", data);
+                .add("response", false)
+                .add("data", data != null, () -> data);
 
         channel.writeAndFlush(builder.build());
         return tag;
@@ -26,11 +26,10 @@ public class ApiUtils {
     }
 
     public static void response(final Channel channel, final String tag, final JsonObject info, final JsonElement data) {
-        final JsonBuilder builder = JsonBuilder.anJSON()
-                .add("tag", tag)
+        final JsonBuilder builder = JsonBuilder.create("tag", tag)
                 .add("info", info)
-                .add("response", true);
-        if (data != null) builder.add("data", data);
+                .add("response", true)
+                .add("data", data != null, () -> data);
 
         channel.writeAndFlush(builder.build());
     }

--- a/java-data/src/main/java/net/cryptic_game/backend/data/Inventory.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/Inventory.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.annotations.Type;
 
@@ -69,8 +69,7 @@ public class Inventory extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("element_name", this.getElementName())
                 .add("owner", this.getOwner().getId())
                 .build();

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatChannel.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatChannel.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.chat;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -108,8 +108,7 @@ public class ChatChannel extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("name", this.getName())
                 .build();
     }

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatChannelAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatChannelAccess.java
@@ -2,8 +2,8 @@ package net.cryptic_game.backend.data.chat;
 
 import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.api.client.ApiClient;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
@@ -162,8 +162,7 @@ public class ChatChannelAccess extends TableModelAutoId {
      * @return The generated {@link JsonObject}
      */
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("user_id", this.getUser().getId())
                 .add("channel_id", this.getChannel().getId())
                 .build();

--- a/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatMessage.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/chat/ChatMessage.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.chat;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
@@ -236,8 +236,7 @@ public class ChatMessage extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("channel", this.getChannel().getId())
                 .add("user", this.getUser().getId())
                 .add("type", this.getType().toString())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/currency/CurrencyAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/currency/CurrencyAccess.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.currency;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.annotations.Type;
 
@@ -74,8 +74,7 @@ public class CurrencyAccess extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("user_id", this.getUser().getId())
                 .add("wallet_id", this.getWallet().getId())
                 .build();

--- a/java-data/src/main/java/net/cryptic_game/backend/data/currency/CurrencyTransaction.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/currency/CurrencyTransaction.java
@@ -2,8 +2,8 @@ package net.cryptic_game.backend.data.currency;
 
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.annotations.Type;
 
@@ -21,7 +21,7 @@ import java.util.Objects;
 @Table(name = "currency_transaction")
 public class CurrencyTransaction extends TableModelAutoId {
 
-    @Column(name = "time_stamp", updatable = false, nullable = false)
+    @Column(name = "timestamp", updatable = false, nullable = false)
     private LocalDateTime timeStamp;
 
     @ManyToOne
@@ -158,9 +158,8 @@ public class CurrencyTransaction extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
-                .add("time_stamp", this.getTimeStamp().toInstant(ZoneOffset.UTC).toEpochMilli())
+        return JsonBuilder.create("id", this.getId())
+                .add("timestamp", this.getTimeStamp().toInstant(ZoneOffset.UTC))
                 .add("source_id", this.getUserSource().getId())
                 .add("SendAmount", this.getSendAmount())
                 .add("destination_id", this.getUserDestination().getId())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/currency/CurrencyWallet.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/currency/CurrencyWallet.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.currency;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -20,7 +20,7 @@ import java.util.Objects;
 @Table(name = "currency_wallet")
 public class CurrencyWallet extends TableModelAutoId {
 
-    @Column(name = "time_stamp", updatable = false, nullable = false)
+    @Column(name = "timestamp", updatable = false, nullable = false)
     private LocalDateTime timeStamp;
 
     @Column(name = "password", updatable = true, nullable = true)
@@ -116,9 +116,8 @@ public class CurrencyWallet extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
-                .add("time_stamp", this.getTimeStamp().toInstant(ZoneOffset.UTC).toEpochMilli())
+        return JsonBuilder.create("id", this.getId())
+                .add("timestamp", this.getTimeStamp().toInstant(ZoneOffset.UTC))
                 .add("send_amount", this.getPassword())
                 .add("destination_uuid", this.getAmount())
                 .build();

--- a/java-data/src/main/java/net/cryptic_game/backend/data/device/Device.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/device/Device.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.device;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
@@ -135,8 +135,7 @@ public class Device extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("name", this.getName())
                 .add("owner", this.getOwner().getId())
                 .add("powered_on", this.isPoweredOn())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceAccess.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceAccess.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.device;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
@@ -198,11 +198,10 @@ public class DeviceAccess extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("target_device", getDevice().getId())
                 .add("device", getUser().getId())
-                .add("granted", getAccessGranted().toInstant(ZoneOffset.UTC).toEpochMilli())
+                .add("granted", getAccessGranted().toInstant(ZoneOffset.UTC))
                 .add("expire", getExpire().toInstant(ZoneOffset.UTC).toEpochMilli())
                 .add("valid", isValid())
                 .build();

--- a/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceFile.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceFile.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.device;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
 
@@ -202,8 +202,7 @@ public class DeviceFile extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("device", this.getDevice().getId())
                 .add("name", this.getName())
                 .add("contents", this.getContent())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceHardware.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceHardware.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.device;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
@@ -119,8 +119,7 @@ public class DeviceHardware extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("device", this.getDevice().getId())
                 .add("element", this.getElement().getId())
                 .add("type", this.getType().toString())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceHardwareElement.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceHardwareElement.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.device;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -93,8 +93,7 @@ public class DeviceHardwareElement extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("name", this.getName())
                 .add("manufacturer", this.getManufacturer())
                 .build();

--- a/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceServiceReq.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceServiceReq.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.device;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.service.Service;
 import org.hibernate.annotations.Type;
 
@@ -176,8 +176,7 @@ public class DeviceServiceReq extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("device", this.getDevice().getId())
                 .add("service", this.getService().getId())
                 .add("allocated_cpu", this.getAllocatedCPU())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceWorkload.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/device/DeviceWorkload.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.device;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModel;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
@@ -293,8 +293,7 @@ public class DeviceWorkload extends TableModel implements Serializable {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("device", this.getDevice().getId())
+        return JsonBuilder.create("device", this.getDevice().getId())
                 .add("performance_cpu", this.getPerformanceCPU())
                 .add("performance_gpu", this.getPerformanceGPU())
                 .add("performance_ram", this.getPerformanceRAM())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/network/Network.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/network/Network.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.network;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.device.Device;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
@@ -205,8 +205,7 @@ public class Network extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("name", this.getName())
                 .add("owner", this.getOwner().getId())
                 .add("public", this.isPublic())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/network/NetworkInvitation.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/network/NetworkInvitation.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.network;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModel;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.device.Device;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
@@ -189,12 +189,11 @@ public class NetworkInvitation extends TableModel {
      */
     @Override
     public JsonObject serialize() {
-        JsonBuilder builder = JsonBuilder.anJSON()
-                .add("network", this.getNetwork().getId())
+        return JsonBuilder.create("network", this.getNetwork().getId())
                 .add("device", this.getDevice().getId())
-                .add("request", this.isRequest());
-        if (this.getInviter() != null) builder.add("inviter", this.getInviter().getId());
-        return builder.build();
+                .add("request", this.isRequest())
+                .add("inviter", this.getInviter() != null, () -> this.getInviter().getId())
+                .build();
     }
 
 

--- a/java-data/src/main/java/net/cryptic_game/backend/data/network/NetworkMember.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/network/NetworkMember.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.network;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModel;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.device.Device;
 import org.hibernate.Session;
 import org.hibernate.annotations.Type;
@@ -148,8 +148,7 @@ public class NetworkMember extends TableModel {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("network", this.getNetwork().getId())
+        return JsonBuilder.create("network", this.getNetwork().getId())
                 .add("device", this.getDevice().getId())
                 .build();
     }

--- a/java-data/src/main/java/net/cryptic_game/backend/data/service/Service.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/service/Service.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.service;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.device.Device;
 import net.cryptic_game.backend.data.user.User;
 import org.hibernate.annotations.Type;
@@ -135,8 +135,7 @@ public class Service extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("device_id", this.getDevice().getId())
                 .add("name", this.getName())
                 .add("isRunning", this.isRunning())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/service/ServiceBruteforce.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/service/ServiceBruteforce.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.service;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
@@ -90,8 +90,7 @@ public class ServiceBruteforce extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("started", this.getStarted())
                 .add("targetService", this.getTargetService().getId())
                 .add("progress", this.getProgress())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/service/ServiceMiner.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/service/ServiceMiner.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.service;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import net.cryptic_game.backend.data.currency.CurrencyWallet;
 import org.hibernate.annotations.Type;
 
@@ -90,8 +90,7 @@ public class ServiceMiner extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("wallet", this.getWallet().getId())
                 .add("started", this.getStarted())
                 .add("power", this.getPower())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/user/Session.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/user/Session.java
@@ -2,8 +2,8 @@ package net.cryptic_game.backend.data.user;
 
 import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.AppBootstrap;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
@@ -220,8 +220,7 @@ public class Session extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("user", this.getId())
                 .add("device_name", this.getDeviceName())
                 .add("valid", this.isValid())

--- a/java-data/src/main/java/net/cryptic_game/backend/data/user/UserSettings.java
+++ b/java-data/src/main/java/net/cryptic_game/backend/data/user/UserSettings.java
@@ -1,8 +1,8 @@
 package net.cryptic_game.backend.data.user;
 
 import com.google.gson.JsonObject;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.sql.models.TableModelAutoId;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
@@ -68,8 +68,7 @@ public class UserSettings extends TableModelAutoId {
      */
     @Override
     public JsonObject serialize() {
-        return JsonBuilder.anJSON()
-                .add("id", this.getId())
+        return JsonBuilder.create("id", this.getId())
                 .add("user", this.getUser().getId())
                 .add("settingValue", this.getSettingValue())
                 .build();

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,12 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "reviewers": [
-    "JannikEmmerich",
-    "MarcelCoding"
-  ],
-  "labels": [
-    "dependencies"
-  ]
+    "extends": [
+        "config:base"
+    ],
+    "reviewers": [
+        "JannikEmmerich",
+        "MarcelCoding"
+    ],
+    "labels": [
+        "dependencies"
+    ]
 }

--- a/server/src/main/java/net/cryptic_game/backend/server/server/daemon/DaemonServerCodec.java
+++ b/server/src/main/java/net/cryptic_game/backend/server/server/daemon/DaemonServerCodec.java
@@ -6,9 +6,9 @@ import net.cryptic_game.backend.base.api.endpoint.ApiEndpointFinder;
 import net.cryptic_game.backend.base.api.endpoint.ApiResponseType;
 import net.cryptic_game.backend.base.api.netty.JsonApiServerCodec;
 import net.cryptic_game.backend.base.daemon.Daemon;
+import net.cryptic_game.backend.base.json.JsonBuilder;
+import net.cryptic_game.backend.base.json.JsonUtils;
 import net.cryptic_game.backend.base.netty.NettyCodec;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
-import net.cryptic_game.backend.base.utils.JsonUtils;
 import net.cryptic_game.backend.server.daemon.DaemonHandler;
 
 import java.util.UUID;
@@ -25,14 +25,13 @@ public class DaemonServerCodec extends NettyCodec<DaemonCodecServerInitializer> 
     }
 
     private void handleResponse(final JsonObject jsonObject, final ApiClient client) {
-        UUID tag = JsonUtils.getUUID(jsonObject, "tag");
+        UUID tag = JsonUtils.fromJson(jsonObject.get("tag"), UUID.class);
         if (this.daemonHandler.isRequstOpen(tag))
             this.daemonHandler.respondToClient(jsonObject);
         else
             client.get(Daemon.class).getChannel()
-                    .writeAndFlush(JsonBuilder.anJSON()
-                            .add("tag", tag)
-                            .add("info", JsonBuilder.anJSON(ApiResponseType.BAD_REQUEST.serialize()).add("message", "TOO_LATE").build())
+                    .writeAndFlush(JsonBuilder.create("tag", tag)
+                            .add("info", JsonBuilder.create(ApiResponseType.BAD_REQUEST).add("message", "TOO_LATE"))
                             .add("response", true)
                             .build());
     }

--- a/server/src/main/java/net/cryptic_game/backend/server/server/http/endpoints/HttpInfoEndpoint.java
+++ b/server/src/main/java/net/cryptic_game/backend/server/server/http/endpoints/HttpInfoEndpoint.java
@@ -4,7 +4,6 @@ import net.cryptic_game.backend.base.api.endpoint.ApiEndpoint;
 import net.cryptic_game.backend.base.api.endpoint.ApiEndpointCollection;
 import net.cryptic_game.backend.base.api.endpoint.ApiResponse;
 import net.cryptic_game.backend.base.api.endpoint.ApiResponseType;
-import net.cryptic_game.backend.base.utils.JsonUtils;
 import net.cryptic_game.backend.server.daemon.DaemonHandler;
 
 public class HttpInfoEndpoint extends ApiEndpointCollection {
@@ -18,7 +17,7 @@ public class HttpInfoEndpoint extends ApiEndpointCollection {
 
     @ApiEndpoint("status")
     public ApiResponse status() {
-        return new ApiResponse(ApiResponseType.OK, JsonUtils.toArray(this.daemonHandler.getDaemons()));
+        return new ApiResponse(ApiResponseType.OK, this.daemonHandler.getDaemons());
     }
 
     @ApiEndpoint("online")

--- a/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketDaemonEndpoints.java
+++ b/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketDaemonEndpoints.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonObject;
 import net.cryptic_game.backend.base.api.client.ApiClient;
 import net.cryptic_game.backend.base.api.endpoint.*;
 import net.cryptic_game.backend.base.daemon.Function;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.data.user.Session;
 import net.cryptic_game.backend.server.App;
 import net.cryptic_game.backend.server.daemon.DaemonHandler;
@@ -46,9 +46,8 @@ public class WebSocketDaemonEndpoints extends ApiEndpointCollection {
 
         App.addTimeout(App.getInstance().getConfig().getResponseTimeout() * 1000, () -> {
             if (daemonHandler.isRequstOpen(requestTag)) {
-                daemonHandler.respondToClient(JsonBuilder.anJSON()
-                        .add("tag", requestTag)
-                        .add("info", JsonBuilder.anJSON(ApiResponseType.BAD_GATEWAY.serialize())
+                daemonHandler.respondToClient(JsonBuilder.create("tag", requestTag)
+                        .add("info", JsonBuilder.create(ApiResponseType.BAD_GATEWAY)
                                 .add("notification", false)
                                 .add("message", "DAEMON_TIMEOUT")
                                 .build())

--- a/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketInfoEndpoints.java
+++ b/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketInfoEndpoints.java
@@ -8,7 +8,7 @@ import net.cryptic_game.backend.base.api.endpoint.ApiResponseType;
 import net.cryptic_game.backend.data.user.Session;
 import net.cryptic_game.backend.server.client.ClientWrapper;
 
-import static net.cryptic_game.backend.base.utils.JsonBuilder.simple;
+import static net.cryptic_game.backend.base.json.JsonBuilder.create;
 
 public class WebSocketInfoEndpoints extends ApiEndpointCollection {
 
@@ -18,7 +18,7 @@ public class WebSocketInfoEndpoints extends ApiEndpointCollection {
 
     @ApiEndpoint("online")
     public ApiResponse online() {
-        return new ApiResponse(ApiResponseType.OK, simple("online", ClientWrapper.getOnlineCount()));
+        return new ApiResponse(ApiResponseType.OK, create("online", ClientWrapper.getOnlineCount()));
     }
 
     @ApiEndpoint("info")

--- a/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketUserEndpoints.java
+++ b/server/src/main/java/net/cryptic_game/backend/server/server/websocket/endpoints/WebSocketUserEndpoints.java
@@ -2,7 +2,7 @@ package net.cryptic_game.backend.server.server.websocket.endpoints;
 
 import net.cryptic_game.backend.base.api.client.ApiClient;
 import net.cryptic_game.backend.base.api.endpoint.*;
-import net.cryptic_game.backend.base.utils.JsonBuilder;
+import net.cryptic_game.backend.base.json.JsonBuilder;
 import net.cryptic_game.backend.base.utils.ValidationUtils;
 import net.cryptic_game.backend.data.user.Session;
 import net.cryptic_game.backend.data.user.User;
@@ -46,8 +46,7 @@ public class WebSocketUserEndpoints extends ApiEndpointCollection {
 
         Session.deleteExpiredSessions(user);
 
-        return new ApiResponse(ApiResponseType.OK, JsonBuilder.anJSON()
-                .add("session", session.getId())
+        return new ApiResponse(ApiResponseType.OK, JsonBuilder.create("session", session.getId())
                 .add("token", token));
     }
 
@@ -83,8 +82,7 @@ public class WebSocketUserEndpoints extends ApiEndpointCollection {
         session = Session.createSession(user, token, deviceName);
         client.add(session);
 
-        return new ApiResponse(ApiResponseType.OK, JsonBuilder.anJSON()
-                .add("session", session.getId())
+        return new ApiResponse(ApiResponseType.OK, JsonBuilder.create("session", session.getId())
                 .add("token", token));
 
     }


### PR DESCRIPTION
**Description**
Replaced all usages of the old `utils.JsonBuilder` and `utils.JsonUtils` with the new ones (`json.JsonBuilder`, `json.JsonUtils`).

**Issue**
Closes #73

**Testing Instructions**
The old `utils.JsonBuilder` and `utils.JsonUtils` should only be used in their own class.

**Additional Notes**
Because `json.JsonBuilder.create()` is deprecated, I replaced `utils.JsonBuilder.anJson().add("ABC", XYZ)` with `json.JsonBuilder.create("ABC", XYZ)`.
